### PR TITLE
ci: update version of node to 22 to match project structure

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f
         with:
-          node-version: 20
+          node-version: 22.20.0
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
this PR updates the version of node from 20 (default) to 22.20.0 which is used on the latest electron release.