### PR TITLE
ci: unifying processes, and updating test run logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,14 +57,11 @@ jobs:
         run: pnpm nx-cloud record -- pnpm nx format:check
 
       # Use affected commands to only run tasks for changed projects
-      - name: Build affected packages
-        run: pnpm nx affected -t build --parallel 4
+      - name: Build and linting affected packages
+        run: pnpm nx affected -t build lint
 
       - name: Run affected unit tests
-        run: pnpm nx affected -t test --parallel 4
-
-      - name: Run affected linting
-        run: pnpm nx affected -t lint --parallel 4
+        run: pnpm nx affected -t test --exclude smoke-test
 
       - name: Check for build artifacts
         id: check_dist


### PR DESCRIPTION
smoke test breaks on linux as it is part of the run of general test.

this PR corrects this by excluding the smoke test outside of the nx affected set of tests, so that it won't break the test on linux